### PR TITLE
Added FlexiPage to package.xml

### DIFF
--- a/generators/app/templates/dynamic/package.xml
+++ b/generators/app/templates/dynamic/package.xml
@@ -40,6 +40,10 @@
   </types>
   <types>
     <members>*</members>
+    <name>FlexiPage</name>
+  </types>
+  <types>
+    <members>*</members>
     <name>Flow</name>
   </types>
   <types>


### PR DESCRIPTION
Added in response to: 

"If you’re looking for aura reference make sure that you sure you have ALL metadata (VF, Aura, LWC, Flexipages, flows, sites, etc.) in your project

let's update the yo generator to include these metadata types"

.. from internal ticket. 

Most of these were already included except for FlexiPage