### PR TITLE
Enable rollback option

### DIFF
--- a/generators/app/templates/static/bitbucket-pipelines.yml
+++ b/generators/app/templates/static/bitbucket-pipelines.yml
@@ -36,6 +36,44 @@ pipelines:
             - dist/**
       - step:
           name: Quick Deploy
+          deployment: production
+          trigger: manual
+          script:
+            - ./build/setup.sh
+            - DEPLOY_ID=$(cat dist/deploy_id.txt)
+            - echo $DEPLOY_ID
+            - sfdx force:mdapi:deploy -q $DEPLOY_ID -w 1000
+            - ./build/merge.sh
+    "rollback/":
+      - step:
+          name: "Build Package"
+          script:
+            - if git log -1 | grep -q "\\[skip ci\\]"; then printf 'CI Commit... Skipping pipeline!'; exit; fi
+            - if [ "${BITBUCKET_PR_DESTINATION_BRANCH}" != "master" ]; then printf 'Destination is not master... Skipping pipeline'; exit; fi
+            - ./build/setup.sh
+            - pr_description=$(curl -s https://${BITBUCKET_USERNAME}:${BITBUCKET_APP_PASSWORD}@api.bitbucket.org/2.0/repositories/${BITBUCKET_REPO_OWNER}/${BITBUCKET_REPO_SLUG}/pullrequests/${BITBUCKET_PR_ID} | jq -r '.description')
+            - SKIP_SYNC=$(echo "$pr_description" | grep -i -c \!skipsync) || true
+            - echo Skip Sync $SKIP_SYNC
+            - ./build/sync.sh $SKIP_SYNC
+            - ./build/package.sh
+          artifacts:
+            - dist/**
+      - step:
+          name: Check Package
+          script:
+            - ./build/setup.sh
+            - pr_description=$(curl -s https://${BITBUCKET_USERNAME}:${BITBUCKET_APP_PASSWORD}@api.bitbucket.org/2.0/repositories/${BITBUCKET_REPO_OWNER}/${BITBUCKET_REPO_SLUG}/pullrequests/${BITBUCKET_PR_ID} | jq -r '.description')
+            - TESTS=$(echo "$pr_description" | grep -i \!tests= | cut -d "=" -f 2-) || true
+            - echo Tests $TESTS
+            - DEPLOY_ID=$(sfdx force:mdapi:deploy ${TESTS:+ -l RunSpecifiedTests -r "${TESTS}"} -d dist/$BITBUCKET_BRANCH -c --json | jq -r .result.id)
+            - echo $DEPLOY_ID
+            - echo $DEPLOY_ID > dist/deploy_id.txt
+            - sfdx force:mdapi:deploy:report --jobid $DEPLOY_ID -w 1000
+          artifacts:
+            - dist/**
+      - step:
+          name: Deploy Rollback
+          deployment: production
           trigger: manual
           script:
             - ./build/setup.sh
@@ -59,6 +97,13 @@ pipelines:
             - ./build/package.sh
             - sfdx force:mdapi:deploy -d dist/$BITBUCKET_BRANCH -w 5000 --verbose
             - ./build/merge.sh
+    Rollback:
+      - variables:
+          - name: CommitHash
+      - step:
+          name: Prepare rollback branch
+          script:
+            - ./build/prepareRollbackBranch.sh $CommitHash
     Deploy to Production (Selective Tests):
       - variables:
           - name: Enter1ToSkipProdSync

--- a/generators/app/templates/static/build/merge.sh
+++ b/generators/app/templates/static/build/merge.sh
@@ -4,8 +4,16 @@
 DEPLOY_SUCCESS=$(sfdx force:mdapi:deploy:report --json | jq .result.success)
 [ $DEPLOY_SUCCESS != 'true' ] && echo "Deployment Failed" && exit 1
 
-# echo 'merge branch into master'
-git checkout master
-git merge $BITBUCKET_BRANCH
-git push
-git push origin --delete $BITBUCKET_BRANCH
+
+echo ''
+echo "Merging and squashing $BITBUCKET_BRANCH into master"
+curl POST -H "Content-Type: application/json" https://${BITBUCKET_USERNAME}:${BITBUCKET_APP_PASSWORD}@api.bitbucket.org/2.0/repositories/${BITBUCKET_WORKSPACE}/${BITBUCKET_REPO_SLUG}/pullrequests/${BITBUCKET_PR_ID}/merge -d '{ "type": "", "close_source_branch": true, "merge_strategy": "squash" }'
+
+# NOTE below on why we are using the bitbucket API to merge and squash the pull request
+# Squashing a pull request in via command line causes the pull requests to remain open in the Bitbucket UI
+
+# https://support.atlassian.com/bitbucket-cloud/docs/merge-a-pull-request/
+# Note: When you enter git merge --squash in the command line locally, the pull request will remain in the ‘open’ state after you push the changes to Bitbucket.
+# This is because we use the commit graph to detect that changes were applied, and when ‘squash merge’ is used, we cannot
+# detect that the pull request was merged or display an accurate diff. The pull request will now contain identical changes
+# between the two branches, so the pull request will show no diff. However, you will be able to see the commit history of the pull request and view the individual commits.

--- a/generators/app/templates/static/build/package.sh
+++ b/generators/app/templates/static/build/package.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
+
 echo 'merge master into branch'
 git merge master
+
+echo ''
 echo 'building package'
 sfdx git:package -d dist/$BITBUCKET_BRANCH -s $BITBUCKET_BRANCH --purge
+
+echo ''
+echo 'building backup'
+sfdx git:package -d dist/backup -s master -t $BITBUCKET_BRANCH -f --purge
+
+echo ''
+echo 'package.xml for deployment'
 cat dist/$BITBUCKET_BRANCH/package.xml

--- a/generators/app/templates/static/build/prepareRollbackBranch.sh
+++ b/generators/app/templates/static/build/prepareRollbackBranch.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "Reverting commit on a rollback branch"
+git stash -u
+git checkout master
+git pull
+git checkout -b rollback/${1}
+git revert ${1} --no-edit
+
+echo ""
+echo "Pushing rollback branch to org"
+git push origin rollback/${1}
+
+echo ""
+echo "Making a pull request"
+curl -X POST -H "Content-Type: application/json" https://${BITBUCKET_USERNAME}:${BITBUCKET_APP_PASSWORD}@api.bitbucket.org/2.0/repositories/${BITBUCKET_WORKSPACE}/${BITBUCKET_REPO_SLUG}/pullrequests -d "{ \"title\": \"rollback/${1}\", \"description\": \"Rolling back commit ${1}\", \"source\": { \"branch\": { \"name\": \"rollback/${1}\" }, \"destination\": { \"branch\": { \"name\": \"master\" } } }, \"close_source_branch\": true }"


### PR DESCRIPTION
Pay attention to this code review as it would tweak the process and this needs to be discussed.

### Changes summary

#### bitbucket-pipelines.yml 

- New custom pipeline for Rollbacks
- For pull requests, perform specific actions if they start with rollback/

#### package.sh

- Always creates a backup of what is already in prod

#### merge.sh

- All merges are now a merge and squash.
- We use the Bitbucket API to perform the merge and squash so it closes the pull request. 
  - Reference note in this file for more info

#### prepareRollbackBranch.sh 

- Creates a new pull request with the revert of a provided commit hash

### Overview:
Going forward, when we deploy a pull request it will perform a merge and squash.
This will make it easier to do a revert in the future.

There is a new custom pipeline that allows for us to specify the commit hash we want reverted.
The custom pipeline will run and create a new pull request that is a revert of the provided hash.

All pull requests that start with rollback/ will automatically build the package and validate the package.
The only thing the user will need to do is click "Deploy Rollback".

### Process change
Because we are making Bitbucket API calls, there is a need for workspace variables 

1. BITBUCKET_USERNAME
2. BITBUCKET_APP_PASSWORD

The app password needs to include the ability to write pull requests.
The above two variables are technically already in the bitbucket pipeline yaml file (reference $tests).
We would need to update the documentation on the pipeline b/c the above to variables are not documented there to begin with.