### PR TITLE
Tie SFDX ClI Version

### DIFF
--- a/generators/app/index.ts
+++ b/generators/app/index.ts
@@ -90,6 +90,7 @@ module.exports = class extends Generator {
         prettier: "^2.x",
         "prettier-plugin-apex": "^1.x",
         "pretty-quick": "^3.x",
+        "sfdx-cli": "^7.106.3",
       },
       husky: {
         hooks: {

--- a/generators/app/index.ts
+++ b/generators/app/index.ts
@@ -90,7 +90,7 @@ module.exports = class extends Generator {
         prettier: "^2.x",
         "prettier-plugin-apex": "^1.x",
         "pretty-quick": "^3.x",
-        "sfdx-cli": "^7.106.3",
+        "sfdx-cli": "7.106.3",
       },
       husky: {
         hooks: {


### PR DESCRIPTION
tie npm commands to a specific sfdx cli version so we don't have to deal with the clean command not working with the latest sfdx cli