### PR TITLE
exclude unneeded and non-critical sf config folders from source control

### DIFF
--- a/generators/app/index.ts
+++ b/generators/app/index.ts
@@ -265,7 +265,7 @@ module.exports = class extends Generator {
       : "";
 
     const currentIgnoreLines = currentIgnore.split(EOL);
-    const defaultIgnores = ["dist/", "node_modules/"];
+    const defaultIgnores = ["dist/", "node_modules/", ".sf/", ".sfdx/"];
     const missing = [];
     for (const defaultIgnore of defaultIgnores) {
       if (!currentIgnoreLines.includes(defaultIgnore)) {


### PR DESCRIPTION
exclude `.sf/` and `.sfdx` folders from source control. no key settings are in there and they have the potential to lead to unexpected org switches happening when you pull or merge