### PR TITLE
Fix npm prerelease publish in CI (2.0.0-alpha.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,17 @@ jobs:
 
       - name: Publish
         # Do not run lifecycle scripts — protects against malicious package scripts at publish time.
-        run: npm publish --ignore-scripts --provenance --access public
+        # Prerelease versions must use an explicit dist-tag; npm rejects publishing them to latest.
+        run: |
+          set -euo pipefail
+          VERSION=$(jq -r '.version' package.json)
+          PUBLISH_ARGS=(--ignore-scripts --provenance --access public)
+          if [[ "${VERSION}" == *-* ]]; then
+            PRERELEASE_TAG="${VERSION##*-}"
+            PRERELEASE_TAG="${PRERELEASE_TAG%%.*}"
+            echo "Prerelease version ${VERSION}; publishing with dist-tag ${PRERELEASE_TAG}"
+            PUBLISH_ARGS+=(--tag "${PRERELEASE_TAG}")
+          fi
+          npm publish "${PUBLISH_ARGS[@]}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+## [2.0.0-alpha.2] - 2026-07-07
 
-- Update CI workflow to current GitHub Action versions (checkout v7, setup-node v6, github-script v9)
+### Fixed
+
+- Publish prerelease versions to npm with the correct dist-tag (`alpha`, `beta`, etc.) so CI publish succeeds when `latest` is a stable release.
 
 ## [2.0.0-alpha.1] - 2026-07-07
 
@@ -28,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replace Yeoman `yo ccc` scaffolding with `npx generator-ccc`; require Node.js 22+; `upgrade` now previews and re-applies templates.
 - Show the plain-language deployment summary ("This deployment contains: 3 Flows, 2 Apex Classes. Deletions: 1 Field.") in the Deployment Package Code Insights card, which needs no repository variables.
+- Update CI workflow to current GitHub Action versions (checkout v7, setup-node v6, github-script v9)
 
 ### Removed
 
@@ -46,5 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use a valid `report_type` (`TEST`) when publishing the deployment package Code Insights card, fixing the HTTP 400 from the Bitbucket Reports API.
 - Stop `insights.sh` printing success messages when the underlying Bitbucket API calls fail; it now logs clear warnings (including likely auth/scope causes) instead.
 
-[Unreleased]: https://github.com/callawaycloud/generator-ccc/compare/v2.0.0-alpha.1...HEAD
+[Unreleased]: https://github.com/callawaycloud/generator-ccc/compare/v2.0.0-alpha.2...HEAD
+[2.0.0-alpha.2]: https://github.com/callawaycloud/generator-ccc/compare/v2.0.0-alpha.1...v2.0.0-alpha.2
 [2.0.0-alpha.1]: https://github.com/callawaycloud/generator-ccc/compare/v2.0.0-alpha.0...v2.0.0-alpha.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generator-ccc",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "generator-ccc",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0-alpha.2",
       "license": "ISC",
       "dependencies": {
         "@clack/prompts": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-ccc",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "One-command setup and upgrade for Callaway Cloud Salesforce projects",
   "type": "module",
   "main": "dist/bin.js",


### PR DESCRIPTION
## Summary
- Fix CI `npm publish` for prerelease versions by deriving the dist-tag (`alpha`, `beta`, etc.) from the semver prerelease identifier
- Bump to `2.0.0-alpha.2` so merge triggers publish through the pipeline (alpha.1 never reached npm because publish failed without `--tag`)

## Test plan
- [ ] CI build-and-test passes
- [ ] Check version bump passes
- [ ] After merge, Publish to npm job succeeds and `generator-ccc@2.0.0-alpha.2` appears on the `alpha` dist-tag

Made with [Cursor](https://cursor.com)