### PR TITLE
Require confirmation before deploying destructive Salesforce metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.3] - 2026-08-24
+
 ### Added
 
 - Require explicit confirmation before validating or deploying destructive metadata: `!confirmDelete` on pull requests and `ConfirmDeletions=DELETE` on custom Deploy to Production pipelines. The Deployment Package report card fails (red) when deletions are present. ([#86](https://github.com/callawaycloud/generator-ccc/issues/86))
@@ -58,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use a valid `report_type` (`TEST`) when publishing the deployment package Code Insights card, fixing the HTTP 400 from the Bitbucket Reports API.
 - Stop `insights.sh` printing success messages when the underlying Bitbucket API calls fail; it now logs clear warnings (including likely auth/scope causes) instead.
 
-[Unreleased]: https://github.com/callawaycloud/generator-ccc/compare/v2.0.0-alpha.2...HEAD
+[Unreleased]: https://github.com/callawaycloud/generator-ccc/compare/v2.0.0-alpha.3...HEAD
+[2.0.0-alpha.3]: https://github.com/callawaycloud/generator-ccc/compare/v2.0.0-alpha.2...v2.0.0-alpha.3
 [2.0.0-alpha.2]: https://github.com/callawaycloud/generator-ccc/compare/v2.0.0-alpha.1...v2.0.0-alpha.2
 [2.0.0-alpha.1]: https://github.com/callawaycloud/generator-ccc/compare/v2.0.0-alpha.0...v2.0.0-alpha.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Require explicit confirmation before validating or deploying destructive metadata: `!confirmDelete` on pull requests and `ConfirmDeletions=DELETE` on custom Deploy to Production pipelines. The Deployment Package report card fails (red) when deletions are present. ([#86](https://github.com/callawaycloud/generator-ccc/issues/86))
+
 ### Fixed
 
 - Declare the GitHub repository in `package.json` so npm Trusted Publisher provenance validation passes, and allow the publish job to be triggered manually via workflow dispatch.
+- Strip empty `destructiveChanges` output from the CI package so `dist/destructiveChanges` only exists when something will actually be deleted. ([#86](https://github.com/callawaycloud/generator-ccc/issues/86))
 
 ## [2.0.0-alpha.2] - 2026-07-07
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generator-ccc",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "generator-ccc",
-      "version": "2.0.0-alpha.2",
+      "version": "2.0.0-alpha.3",
       "license": "ISC",
       "dependencies": {
         "@clack/prompts": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-ccc",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "One-command setup and upgrade for Callaway Cloud Salesforce projects",
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ That's it. The CLI will:
 
 ## What gets configured
 
-1. **Bitbucket Pipelines CI/CD** — validate on PR, manual check + quick deploy, automatic merge and branch cleanup, scheduled production sync, JUnit test reporting, deployment dashboard, inline PR annotations, and automatic destructive-change handling. See the generated `docs/ci.md` for the full guide.
+1. **Bitbucket Pipelines CI/CD** — validate on PR, manual check + quick deploy, automatic merge and branch cleanup, scheduled production sync, JUnit test reporting, deployment dashboard, inline PR annotations, and destructive-change handling that requires explicit confirmation before anything is deleted. See the generated `docs/ci.md` for the full guide.
 2. **Cursor / VS Code** — palette tasks for common Salesforce operations (retrieve, preview deployment package, run tests, open org), recommended extensions, Cursor project rules (`.cursor/rules/`), Cursor skills (`.cursor/skills/`), and the official Salesforce MCP server (`.cursor/mcp.json`).
 3. **Formatting** — prettier 3 with `prettier-plugin-apex` and a husky pre-commit hook.
 4. **Project defaults** — `manifest/package.xml`, `.gitignore` entries, VS Code settings, and npm scripts.

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -17,6 +17,7 @@ export interface DoctorCheck {
 
 const REQUIRED_FILES = [
   "bitbucket-pipelines.yml",
+  "build/destructive-guard.sh",
   "build/format-commit.sh",
   "build/insights.sh",
   "build/merge.sh",
@@ -30,6 +31,7 @@ const REQUIRED_FILES = [
 ] as const;
 
 const REQUIRED_SHELL_FILES = [
+  "build/destructive-guard.sh",
   "build/format-commit.sh",
   "build/insights.sh",
   "build/merge.sh",

--- a/templates/static/.cursor/rules/salesforce-project.mdc
+++ b/templates/static/.cursor/rules/salesforce-project.mdc
@@ -14,7 +14,7 @@ The `{{defaultBranch}}` branch mirrors production and must **never** be committe
 ## Deployment Workflow
 
 1. **Build Package** (automatic on PR) — syncs production into `{{defaultBranch}}`, merges it into the PR branch, and builds an incremental deployment package with sfdx-git-delta (including `destructiveChanges.xml` when needed).
-2. **Check Package** (manual) — runs a check-only deployment with tests; results appear on the PR.
+2. **Check Package** (manual) — runs a check-only deployment with tests; results appear on the PR. Blocked until the PR description contains `!confirmDelete` if the package includes deletions.
 3. **Quick Deploy** (manual) — performs the quick deploy, auto-merges the branch into `{{defaultBranch}}`, and deletes the feature branch.
 
 ## Preview a Deployment Package Locally
@@ -25,6 +25,7 @@ Run the **SF: Preview Deployment Package** task (or `sf sgd source delta --from 
 
 - `!skipSync` — skip the production sync during Build Package.
 - `!tests=Foo,Bar` — run only the listed Apex test classes during Check Package.
+- `!confirmDelete` — required when the package contains deletions; Check Package fails until this flag is in the PR description.
 
 ## Formatting
 

--- a/templates/static/.cursor/skills/deploy-salesforce-changes/SKILL.md
+++ b/templates/static/.cursor/skills/deploy-salesforce-changes/SKILL.md
@@ -15,15 +15,16 @@ description: Deploy Salesforce metadata changes to production via the Bitbucket 
 2. **Commit your changes** under `src/` with a clear message.
 3. **Open a pull request** targeting `{{defaultBranch}}`.
 4. **Build Package** (automatic on PR) — syncs production into `{{defaultBranch}}`, merges into the PR branch, builds an incremental package via sfdx-git-delta.
-5. **Check Package** (manual) — check-only deploy with tests; results appear on the PR. Review test results before proceeding.
+5. **Check Package** (manual) — check-only deploy with tests; results appear on the PR. Review test results before proceeding. Blocked until the PR description contains `!confirmDelete` if the package includes deletions.
 6. **Quick Deploy** (manual) — quick deploys to production, auto-merges to `{{defaultBranch}}`, deletes the feature branch.
 
 ## PR description flags
 
-| Flag             | Effect                                            |
-| ---------------- | ------------------------------------------------- |
-| `!skipSync`      | Skip production sync during Build Package         |
-| `!tests=Foo,Bar` | Run only listed test classes during Check Package |
+| Flag             | Effect                                                                                                     |
+| ---------------- | ---------------------------------------------------------------------------------------------------------- |
+| `!skipSync`      | Skip production sync during Build Package                                                                  |
+| `!tests=Foo,Bar` | Run only listed test classes during Check Package                                                          |
+| `!confirmDelete` | Required when the package contains deletions; Check Package fails until this flag is in the PR description |
 
 ## Full pipeline guide
 

--- a/templates/static/bitbucket-pipelines.yml
+++ b/templates/static/bitbucket-pipelines.yml
@@ -12,7 +12,7 @@ definitions:
     - &setup bash build/setup.sh
     - &destructive-args |
       DESTRUCTIVE_ARGS=""
-      if [ -f dist/destructiveChanges/destructiveChanges.xml ] && grep -q '<members>' dist/destructiveChanges/destructiveChanges.xml 2>/dev/null; then
+      if [ -f dist/destructiveChanges/destructiveChanges.xml ]; then
         DESTRUCTIVE_ARGS="--post-destructive-changes dist/destructiveChanges/destructiveChanges.xml"
       fi
     - &fetch-pr-description pr_description=$(curl --fail --show-error -s -u "${BITBUCKET_USERNAME}:${BITBUCKET_APP_PASSWORD}" "https://api.bitbucket.org/2.0/repositories/${BITBUCKET_REPO_OWNER}/${BITBUCKET_REPO_SLUG}/pullrequests/${BITBUCKET_PR_ID}" | jq -r '.description') || pr_description=""
@@ -23,6 +23,13 @@ definitions:
         SKIP_SYNC=0
       fi
       echo "Skip Sync ${SKIP_SYNC}"
+    - &parse-confirmdelete |
+      if echo "$pr_description" | grep -qi '!confirmdelete'; then
+        CONFIRM_DELETE=1
+      else
+        CONFIRM_DELETE=0
+      fi
+      echo "Confirm Delete ${CONFIRM_DELETE}"
     - &parse-tests-from-pr |
       TESTS=$(echo "$pr_description" | grep -i '!tests=' | cut -d "=" -f 2-) || true
       TESTS="${TESTS//,/ }"
@@ -74,7 +81,9 @@ pipelines:
             - *setup
             - *fetch-pr-description
             - *parse-tests-from-pr
+            - *parse-confirmdelete
             - *destructive-args
+            - bash build/destructive-guard.sh "$CONFIRM_DELETE"
             - |
               VALIDATE_JSON=$(sf project deploy validate -x dist/package/package.xml ${DESTRUCTIVE_ARGS} ${TEST_ARGS} --junit --results-dir test-results --async --json)
               echo "${VALIDATE_JSON}" | jq -r '.result.id' > dist/deploy_id.txt
@@ -117,6 +126,7 @@ pipelines:
     Deploy to Production:
       - variables:
           - name: Enter1ToSkipProdSync
+          - name: ConfirmDeletions
       - step:
           <<: *sf-cached-step
           deployment: production
@@ -125,6 +135,12 @@ pipelines:
             - bash build/sync.sh "$Enter1ToSkipProdSync"
             - bash build/package.sh
             - *destructive-args
+            - |
+              if [ "${ConfirmDeletions:-}" = "DELETE" ]; then
+                bash build/destructive-guard.sh 1
+              else
+                bash build/destructive-guard.sh 0
+              fi
             - |
               DEPLOY_JSON=$(sf project deploy start --manifest dist/package/package.xml ${DESTRUCTIVE_ARGS} --test-level RunLocalTests --junit --results-dir test-results --async --json)
               echo "${DEPLOY_JSON}" | jq -r '.result.id' > dist/deploy_id.txt
@@ -138,6 +154,7 @@ pipelines:
       - variables:
           - name: Enter1ToSkipProdSync
           - name: Tests
+          - name: ConfirmDeletions
       - step:
           <<: *sf-cached-step
           deployment: production
@@ -146,6 +163,12 @@ pipelines:
             - bash build/sync.sh "$Enter1ToSkipProdSync"
             - bash build/package.sh
             - *destructive-args
+            - |
+              if [ "${ConfirmDeletions:-}" = "DELETE" ]; then
+                bash build/destructive-guard.sh 1
+              else
+                bash build/destructive-guard.sh 0
+              fi
             - |
               TESTS="${Tests//,/ }"
               DEPLOY_JSON=$(sf project deploy start --manifest dist/package/package.xml ${DESTRUCTIVE_ARGS} --test-level RunSpecifiedTests --tests ${TESTS} --junit --results-dir test-results --async --json)

--- a/templates/static/build/destructive-guard.sh
+++ b/templates/static/build/destructive-guard.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Blocks Salesforce validate/deploy when the delta package includes metadata
+# deletions, unless the caller passed "1" as the first argument (confirmed).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/package-stats.sh
+source "${SCRIPT_DIR}/lib/package-stats.sh"
+
+DESTRUCTIVE_XML="dist/destructiveChanges/destructiveChanges.xml"
+CONFIRMED="${1:-}"
+
+_has_destructive_deletions() {
+  [ -f "$DESTRUCTIVE_XML" ] && grep -q '<members>' "$DESTRUCTIVE_XML"
+}
+
+# Print a high-visibility line to pipeline logs.
+_loud() {
+  echo "$@"
+}
+
+_print_destructive_xml() {
+  echo "=== Destructive changes (raw XML) ==="
+  cat "$DESTRUCTIVE_XML"
+}
+
+if ! _has_destructive_deletions; then
+  exit 0
+fi
+
+if [ "$CONFIRMED" = "1" ]; then
+  _loud ""
+  _loud "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  _loud "!!! DESTRUCTIVE CHANGES CONFIRMED — PROCEEDING WITH DELETE !!!"
+  _loud "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  _loud ""
+  _loud "Summary: $(friendly_summary "$DESTRUCTIVE_XML")"
+  _loud ""
+  _print_destructive_xml
+  _loud ""
+  exit 0
+fi
+
+_loud ""
+_loud "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+_loud "!!! DESTRUCTIVE CHANGES BLOCKED !!!"
+_loud "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+_loud ""
+_loud "This deployment would DELETE the following Salesforce metadata:"
+_loud ""
+_loud "Summary: $(friendly_summary "$DESTRUCTIVE_XML")"
+_loud ""
+_print_destructive_xml
+_loud ""
+_loud "WARNING: This removes metadata from your Salesforce org — not just files in git."
+_loud "Deleting custom fields or objects can permanently destroy data in production."
+_loud "Renaming an API name counts as delete + create, not an in-place rename."
+_loud ""
+_loud "To confirm and allow this deployment:"
+_loud "  - Pull request: add !confirmDelete to the PR description, then re-run Check Package."
+_loud "  - Custom Deploy to Production pipelines: re-run and set ConfirmDeletions to exactly DELETE."
+_loud ""
+exit 1

--- a/templates/static/build/insights.sh
+++ b/templates/static/build/insights.sh
@@ -17,7 +17,7 @@ usage() {
 }
 
 _has_destructive_members() {
-  [ -f "$DESTRUCTIVE_XML" ] && grep -q '<members>' "$DESTRUCTIVE_XML"
+  [ -f "$DESTRUCTIVE_XML" ]
 }
 
 _metadata_types_text() {
@@ -64,12 +64,16 @@ package_report() {
 
   # The details text renders on the PR card, so it carries the human-readable
   # summary — visible without any repository variables configured.
-  if [ "$total" -gt 0 ]; then
+  if [ "$has_destructive" = "true" ]; then
+    result="FAILED"
+    details="WARNING: this package DELETES metadata — add !confirmDelete to the PR description to allow Check Package."
+    if [ "$total" -gt 0 ]; then
+      details="${details} This deployment contains: $(friendly_summary "$PACKAGE_XML")."
+    fi
+    details="${details} Deletions: $(friendly_summary "$DESTRUCTIVE_XML")."
+  elif [ "$total" -gt 0 ]; then
     result="PASSED"
     details="This deployment contains: $(friendly_summary "$PACKAGE_XML")."
-    if [ "$has_destructive" = "true" ]; then
-      details="${details} Deletions: $(friendly_summary "$DESTRUCTIVE_XML")."
-    fi
   else
     details="No deployable changes detected"
   fi

--- a/templates/static/build/package.sh
+++ b/templates/static/build/package.sh
@@ -8,20 +8,40 @@ echo "=== Building delta package with sfdx-git-delta ==="
 mkdir -p dist
 sf sgd source delta --from "origin/{{defaultBranch}}" --to HEAD --output-dir dist --generate-delta
 
-echo "=== Package manifest ==="
-cat dist/package/package.xml
-
-if [ -f dist/destructiveChanges/destructiveChanges.xml ]; then
-  echo "=== Destructive changes ==="
-  cat dist/destructiveChanges/destructiveChanges.xml
-fi
-
 # shellcheck source=lib/package-stats.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/package-stats.sh"
 
+# Strip empty destructiveChanges/ from artifacts unless real deletions are present
+DESTRUCTIVE_XML="dist/destructiveChanges/destructiveChanges.xml"
+if [ -f "$DESTRUCTIVE_XML" ] && grep -q '<members>' "$DESTRUCTIVE_XML"; then
+  echo ""
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  echo "!!! DESTRUCTIVE CHANGES DETECTED !!!"
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  echo ""
+  echo "Summary: $(friendly_summary "$DESTRUCTIVE_XML")"
+  echo ""
+  echo "=== Destructive changes (raw XML) ==="
+  cat "$DESTRUCTIVE_XML"
+  echo ""
+  echo "Check Package and deploy are BLOCKED until you confirm deletions."
+  echo "Add !confirmDelete to the PR description, or set ConfirmDeletions=DELETE on custom Deploy pipelines."
+else
+  rm -rf dist/destructiveChanges
+fi
+
+echo "=== Package manifest ==="
+cat dist/package/package.xml
+
 echo "=== Next steps ==="
 TOTAL="$(package_total "dist/package/package.xml")"
-if [ "$TOTAL" -eq 0 ]; then
+if [ -f "$DESTRUCTIVE_XML" ]; then
+  echo "Package includes metadata deletions ($(friendly_summary "$DESTRUCTIVE_XML"))."
+  echo "Check Package and custom Deploy pipelines will FAIL until you confirm: add !confirmDelete to the PR description, or set ConfirmDeletions=DELETE on custom Deploy pipelines."
+  if [ "$TOTAL" -gt 0 ]; then
+    echo "Also includes ${TOTAL} components to add or update."
+  fi
+elif [ "$TOTAL" -eq 0 ]; then
   echo "No deployable changes detected between this branch and {{defaultBranch}}."
 else
   echo "Package built with ${TOTAL} components. Next: click 'Check Package' on this pipeline when you're ready to validate against production."

--- a/templates/static/docs/ci.md
+++ b/templates/static/docs/ci.md
@@ -57,17 +57,21 @@ Build Package:
 2. Merges `{{defaultBranch}}` into your feature branch so conflicts surface early.
 3. Builds an incremental deployment package with sfdx-git-delta, including `destructiveChanges.xml` when deletions are detected.
 
+Empty `destructiveChanges` output is stripped — `dist/destructiveChanges` only exists when something will actually be deleted. When real deletions are present, the pipeline logs a loud banner and the **Deployment Package** report card fails (red).
+
 When it finishes, download the pipeline artifacts to inspect `package.xml` and `destructiveChanges.xml` if needed.
 
 ### 5. Run Check Package
 
 Click **Check Package** in the pipeline. This performs a check-only deployment against production and runs Apex tests. Test results are posted on the pull request.
 
+If the package contains deletions, **Check Package** is blocked until you add `!confirmDelete` to the PR description. Review the destructive-changes XML in the pipeline artifacts before confirming.
+
 Review the results before proceeding. If tests fail, fix the issues on your branch and push — Build Package will run again.
 
 ### 6. Quick Deploy
 
-When Check Package succeeds and the PR is approved, click **Quick Deploy**. This:
+When Check Package succeeds and the PR is approved, click **Quick Deploy**. Quick Deploy only runs after a successful Check Package, so it does not re-prompt for deletion confirmation. This:
 
 1. Deploys the previously validated package to production (no re-run of tests).
 2. Merges your branch into `{{defaultBranch}}`.
@@ -77,7 +81,7 @@ You are done. Production and `{{defaultBranch}}` are back in sync.
 
 ## PR report cards
 
-After **Build Package** completes, a **Deployment Package** report card appears on the pull request with a plain-language summary of the package contents ("This deployment contains: 3 Flows, 2 Apex Classes. Deletions: 1 Field."), plus component count, metadata types, and a destructive-changes indicator.
+After **Build Package** completes, a **Deployment Package** report card appears on the pull request with a plain-language summary of the package contents ("This deployment contains: 3 Flows, 2 Apex Classes. Deletions: 1 Field."), plus component count, metadata types, and a destructive-changes indicator. When the package includes deletions, the card **fails (red)** with a warning that Check Package needs `!confirmDelete`.
 
 After Build Package, a **Code Analysis** report card summarizes Salesforce Code Analyzer findings for changed files, and each finding is pinned as an inline annotation on the exact file and line in the PR diff (severity-badged, sorted by severity, capped at Bitbucket's 1,000-annotation limit).
 
@@ -89,10 +93,11 @@ Report cards and inline annotations use Bitbucket's in-pipeline authentication, 
 
 Add these anywhere in the pull request description. They are case-insensitive.
 
-| Flag             | What it does                                                           | When to use                                                                         |
-| ---------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `!skipSync`      | Skips syncing production into `{{defaultBranch}}` during Build Package | You know production has not changed since the last sync and want a faster build     |
-| `!tests=Foo,Bar` | Runs only the listed Apex test classes during Check Package            | Large orgs where a full test run is slow and you know which tests cover your change |
+| Flag             | What it does                                                                                               | When to use                                                                              |
+| ---------------- | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `!skipSync`      | Skips syncing production into `{{defaultBranch}}` during Build Package                                     | You know production has not changed since the last sync and want a faster build          |
+| `!tests=Foo,Bar` | Runs only the listed Apex test classes during Check Package                                                | Large orgs where a full test run is slow and you know which tests cover your change      |
+| `!confirmDelete` | Required when the package contains deletions; Check Package fails until this flag is in the PR description | You have reviewed `destructiveChanges.xml` and intend to delete metadata from production |
 
 Example:
 
@@ -102,18 +107,24 @@ Update Account validation rule.
 !tests=AccountValidationTest,AccountTriggerTest
 ```
 
+## Destructive changes
+
+Deleting or renaming metadata in git relative to the production branch (`{{defaultBranch}}`) becomes a Salesforce metadata deletion in the deployment package. API-name renames are treated as delete plus create — for fields and objects this means data loss. Custom fields and custom objects often go to the Salesforce recycle bin for about 15 days; Apex classes and LWC bundles are removed from the org but remain in git history.
+
+The pipeline never deletes Salesforce **records** — only metadata definitions.
+
 ## Manual pipelines
 
 Beyond the PR pipeline, you can run these from **Pipelines → Run pipeline → Custom**:
 
-| Pipeline                                   | What it does                                                                                                      | When to use                                                                                      |
-| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| **Sync Production**                        | Pulls production metadata into `{{defaultBranch}}` and commits                                                    | Production changed outside the normal PR flow and you need `{{defaultBranch}}` updated now       |
-| **Deploy to Production**                   | Syncs production, builds a package from the current branch, deploys with all tests, merges to `{{defaultBranch}}` | Emergency or hotfix deploy from a branch without going through the PR Check/Quick Deploy steps   |
-| **Deploy to Production (Selective Tests)** | Same as above but runs only the test classes you specify                                                          | Hotfix where you need a faster deploy and know which tests to run                                |
-| **Scheduled Production Sync**              | Checks when production was last synced; syncs if the interval has elapsed                                         | Runs on a schedule to keep `{{defaultBranch}}` close to production even when no one is deploying |
+| Pipeline                                   | What it does                                                                                                                                                                                                                                | When to use                                                                                      |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| **Sync Production**                        | Pulls production metadata into `{{defaultBranch}}` and commits                                                                                                                                                                              | Production changed outside the normal PR flow and you need `{{defaultBranch}}` updated now       |
+| **Deploy to Production**                   | Syncs production, builds a package from the current branch, deploys with all tests, merges to `{{defaultBranch}}`. Fails before deploy if the package has deletions unless run-time variable `ConfirmDeletions` is set to exactly `DELETE`. | Emergency or hotfix deploy from a branch without going through the PR Check/Quick Deploy steps   |
+| **Deploy to Production (Selective Tests)** | Same as above but runs only the test classes you specify. Fails before deploy if the package has deletions unless `ConfirmDeletions` is set to exactly `DELETE`.                                                                            | Hotfix where you need a faster deploy and know which tests to run                                |
+| **Scheduled Production Sync**              | Checks when production was last synced; syncs if the interval has elapsed                                                                                                                                                                   | Runs on a schedule to keep `{{defaultBranch}}` close to production even when no one is deploying |
 
-For **Deploy to Production** pipelines, set **Enter1ToSkipProdSync** to `1` if you want to skip the production sync step.
+For **Deploy to Production** pipelines, set **Enter1ToSkipProdSync** to `1` if you want to skip the production sync step. If the package contains deletions, set **ConfirmDeletions** to exactly `DELETE` after reviewing the destructive-changes XML.
 
 ## Scheduled production sync
 
@@ -135,7 +146,7 @@ Recommended schedule: daily at a low-traffic time (for example 3:00 AM), branch 
 | `BITBUCKET_USERNAME`     | Yes     | Bitbucket account username for REST API calls |
 | `BITBUCKET_APP_PASSWORD` | Yes     | Bitbucket app password for REST API calls     |
 
-These are required to parse PR description flags (`!skipSync`, `!tests=`) during **Build Package** and **Check Package**, and to open pull requests when `SYNC_AS_PR=1`. Add them as secured repository variables alongside the others.
+These are required to parse PR description flags (`!skipSync` during **Build Package**; `!tests=` and `!confirmDelete` during **Check Package**), and to open pull requests when `SYNC_AS_PR=1`. Add them as secured repository variables alongside the others.
 
 ## Setup
 
@@ -151,12 +162,13 @@ If you need to configure Bitbucket yourself:
 
 ## Troubleshooting
 
-| Symptom                                          | Likely cause                                                    | What to do                                                                                                                                                                   |
-| ------------------------------------------------ | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Pipeline fails immediately with auth error       | `AUTH_URL` expired or invalid                                   | Re-authorize the production org, run `sf org display --verbose`, update the secured `AUTH_URL` variable                                                                      |
-| Build Package fails on merge                     | Conflict between your branch and synced `{{defaultBranch}}`     | Pull latest `{{defaultBranch}}`, merge or rebase into your feature branch, resolve conflicts, push                                                                           |
-| Quick Deploy fails with "validation invalidated" | Too much time passed since Check Package, or production changed | Re-run **Check Package**, then try Quick Deploy again                                                                                                                        |
-| Check Package reports test failures              | Apex tests failed against the check-only deploy                 | Fix failing tests or metadata on your branch, push, wait for Build Package, re-run Check Package                                                                             |
-| Scheduled sync never runs                        | Schedule not created or interval not elapsed                    | Confirm the schedule exists on `{{defaultBranch}}`; check `PRODUCTION_SYNC_INTERVAL` value and last sync commit message                                                      |
-| Package is empty or missing expected metadata    | Change not committed or not in `src/`                           | Verify files are tracked in git under `src/`; run the **SF: Preview Deployment Package** task locally to compare                                                             |
-| No report cards or inline annotations on the PR  | Report publishing skipped or failed (it never blocks the build) | Check the Build Package or Check Package log for WARN lines from `insights.sh`; annotations on lines not part of the PR diff are only visible in the report view, not inline |
+| Symptom                                                                        | Likely cause                                                    | What to do                                                                                                                                                                   |
+| ------------------------------------------------------------------------------ | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pipeline fails immediately with auth error                                     | `AUTH_URL` expired or invalid                                   | Re-authorize the production org, run `sf org display --verbose`, update the secured `AUTH_URL` variable                                                                      |
+| Build Package fails on merge                                                   | Conflict between your branch and synced `{{defaultBranch}}`     | Pull latest `{{defaultBranch}}`, merge or rebase into your feature branch, resolve conflicts, push                                                                           |
+| Quick Deploy fails with "validation invalidated"                               | Too much time passed since Check Package, or production changed | Re-run **Check Package**, then try Quick Deploy again                                                                                                                        |
+| Check Package reports test failures                                            | Apex tests failed against the check-only deploy                 | Fix failing tests or metadata on your branch, push, wait for Build Package, re-run Check Package                                                                             |
+| Scheduled sync never runs                                                      | Schedule not created or interval not elapsed                    | Confirm the schedule exists on `{{defaultBranch}}`; check `PRODUCTION_SYNC_INTERVAL` value and last sync commit message                                                      |
+| Package is empty or missing expected metadata                                  | Change not committed or not in `src/`                           | Verify files are tracked in git under `src/`; run the **SF: Preview Deployment Package** task locally to compare                                                             |
+| No report cards or inline annotations on the PR                                | Report publishing skipped or failed (it never blocks the build) | Check the Build Package or Check Package log for WARN lines from `insights.sh`; annotations on lines not part of the PR diff are only visible in the report view, not inline |
+| Check Package or custom Deploy fails with a destructive-changes blocked banner | Deletions in the package without explicit confirmation          | Add `!confirmDelete` to the PR description (after reviewing `destructiveChanges.xml`), or re-run the custom **Deploy to Production** pipeline with `ConfirmDeletions=DELETE` |

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -25,6 +25,7 @@ const BUILD_SCRIPTS = [
   "build/package.sh",
   "build/merge.sh",
   "build/format-commit.sh",
+  "build/destructive-guard.sh",
   "build/schedule.sh",
 ] as const;
 


### PR DESCRIPTION
Fixes #86

## Summary
- Strip empty `destructiveChanges` output so `dist/destructiveChanges` only exists when something will actually be deleted.
- Print a loud banner when deletions are in the package, and fail the Deployment Package Code Insights card (red) so they cannot be missed.
- Block Check Package until the PR description contains `!confirmDelete`. Block custom Deploy to Production pipelines until `ConfirmDeletions` is set to `DELETE`.

## Test plan
- [ ] Scaffold or upgrade a project and confirm `build/destructive-guard.sh` is present and executable (`ccc doctor`).
- [ ] Open a PR with no deletions: Build Package artifacts have no `dist/destructiveChanges` directory; Check Package is not blocked.
- [ ] Open a PR that deletes metadata: Build Package logs `!!! DESTRUCTIVE CHANGES DETECTED !!!`; Deployment Package card is red; Check Package fails with `!!! DESTRUCTIVE CHANGES BLOCKED !!!` until `!confirmDelete` is added to the PR description, then Check Package proceeds.
- [ ] Run custom **Deploy to Production** with deletions and leave `ConfirmDeletions` empty: step fails before `sf project deploy start`. Re-run with `ConfirmDeletions=DELETE` and confirm the guard allows the deploy.
- [ ] Confirm Quick Deploy still has no extra prompt (it only replays a validation that already passed the guard).
